### PR TITLE
feat: add prefix for env vars

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,16 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-deny
+      - name: Scan for vulnerabilities
+        run: cargo deny check advisories

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,9 @@
 name: Building
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: stable
+
 permissions:
   contents: read
 
@@ -14,9 +19,9 @@ jobs:
 
     steps:
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{env.RUST_TOOLCHAIN}}
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN_NIGHTLY}}"
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check Formatting
         run: cargo +nightly fmt --all -- --check
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,7 @@
 name: Lint and Format Check
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: stable
 permissions:
   contents: read
 
@@ -14,12 +17,17 @@ jobs:
 
     steps:
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{env.RUST_TOOLCHAIN}}
+          components: clippy, rustfmt
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN}}"
 
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check Formatting
-        run: cargo fmt --check
+        run: cargo fmt --all -- --check
 
       - name: Run Clippy
         run: cargo clippy -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint and Format Check
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN: stable
+  RUST_TOOLCHAIN_NIGHTLY: nightly
 permissions:
   contents: read
 
@@ -17,9 +18,9 @@ jobs:
 
     steps:
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${{env.RUST_TOOLCHAIN}}
+          toolchain: ${{env.RUST_TOOLCHAIN_NIGHTLY}}
           components: clippy, rustfmt
 
       - name: Checkout code
@@ -27,10 +28,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN}}"
+          env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN_NIGHTLY}}"
 
       - name: Check Formatting
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Run Clippy
         run: cargo clippy -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Testing
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: stable
 permissions:
   contents: read
 
@@ -14,12 +17,16 @@ jobs:
 
     steps:
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{env.RUST_TOOLCHAIN}}
 
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN}}"
 
       - name: Run Tests
         run: cargo test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,10 @@ jobs:
         with:
           env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN}}"
 
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Tests
         run: cargo test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ cargo test
 We have linting and formatting tools to check the code convention. Please make sure you are following the Rust code convention.
 Format your change by running this command:
 ```
-cargo fmt
+cargo fmt --all
 cargo clippy --all-targets --all-features
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "mockall",
  "nix",
  "predicates",
+ "procedural",
  "prost 0.13.5",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1.0"
 chrono = "0.4"
 prost = "0.13"
 dotenv = "0.15"
+procedural = { path = "common/procedural" }
 
 # Binary dependencies
 ctrlc = { version = "3.4" }

--- a/common/procedural/src/lib.rs
+++ b/common/procedural/src/lib.rs
@@ -87,10 +87,7 @@ pub fn derive_env_prefix(input: TokenStream) -> TokenStream {
             },
             Err(_) => None,
         })
-        .unwrap_or_else(|| {
-            eprintln!("Warning: No #[prefix = \"...\"] attribute found, using default prefix \"\"");
-            "".to_string()
-        });
+        .unwrap_or_default();
 
     let name = &ast.ident;
 

--- a/common/procedural/src/lib.rs
+++ b/common/procedural/src/lib.rs
@@ -4,7 +4,12 @@ use quote::{
     quote_spanned,
 };
 use syn::{
-    self, parse_macro_input, DeriveInput, Lit, Meta, NestedMeta
+    self,
+    DeriveInput,
+    Lit,
+    Meta,
+    NestedMeta,
+    parse_macro_input,
 };
 
 #[proc_macro_derive(Topic, attributes(topic_name))]
@@ -65,24 +70,22 @@ pub fn derive_env_prefix(input: TokenStream) -> TokenStream {
 
     // println!("Debug: All attributes: {:?}", ast.attrs);
 
-    let prefix = ast.attrs.iter()
+    let prefix = ast
+        .attrs
+        .iter()
         .find(|attr| attr.path.is_ident("prefix"))
-        .and_then(|attr| {
-            match attr.parse_meta() {
-                Ok(meta) => {
-                    match meta {
-                        Meta::NameValue(name_value) => {
-                            if let Lit::Str(s) = name_value.lit {
-                                Some(s.value())
-                            } else {
-                                None
-                            }
-                        },
-                        _ => None
+        .and_then(|attr| match attr.parse_meta() {
+            Ok(meta) => match meta {
+                Meta::NameValue(name_value) => {
+                    if let Lit::Str(s) = name_value.lit {
+                        Some(s.value())
+                    } else {
+                        None
                     }
-                },
-                Err(_) => None
-            }
+                }
+                _ => None,
+            },
+            Err(_) => None,
         })
         .unwrap_or_else(|| "EZEX".to_string());
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,6 +2,6 @@ pub mod consts;
 pub mod database;
 pub mod logger;
 pub mod redis;
+pub mod testsuite;
 pub mod topic;
 pub mod utils;
-pub mod testsuite;

--- a/common/src/logger/config.rs
+++ b/common/src/logger/config.rs
@@ -1,13 +1,15 @@
 use clap::Args;
+use procedural::EnvPrefix;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, EnvPrefix)]
+#[prefix = "EZEX_DEPOSIT"]
 #[group(id = "logger")]
 pub struct Config {
-    #[arg(long = "logger-file", env = "EZEX_DEPOSIT_LOGGER_FILE")]
+    #[arg(long = "logger-file", env = "LOGGER_FILE")]
     pub file: String,
     #[arg(
         long = "logger-level",
-        env = "EZEX_DEPOSIT_LOGGER_LEVEL",
+        env = "LOGGER_LEVEL",
         default_value = "info"
     )]
     pub level: String,

--- a/common/src/logger/config.rs
+++ b/common/src/logger/config.rs
@@ -7,10 +7,6 @@ use procedural::EnvPrefix;
 pub struct Config {
     #[arg(long = "logger-file", env = "LOGGER_FILE")]
     pub file: String,
-    #[arg(
-        long = "logger-level",
-        env = "LOGGER_LEVEL",
-        default_value = "info"
-    )]
+    #[arg(long = "logger-level", env = "LOGGER_LEVEL", default_value = "info")]
     pub level: String,
 }

--- a/common/src/logger/config.rs
+++ b/common/src/logger/config.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
-#[prefix = "EZEX_DEPOSIT"]
+#[env_prefix = "EZEX_DEPOSIT"]
 #[group(id = "logger")]
 pub struct Config {
     #[arg(long = "logger-file", env = "LOGGER_FILE")]

--- a/common/src/testsuite/mod.rs
+++ b/common/src/testsuite/mod.rs
@@ -1,8 +1,6 @@
 pub mod postgres;
 pub mod redis;
 
-
 pub fn pick_unused_port() -> u16 {
     portpicker::pick_unused_port().unwrap()
 }
-

--- a/common/src/testsuite/postgres.rs
+++ b/common/src/testsuite/postgres.rs
@@ -1,15 +1,25 @@
 use crate::topic::TopicMessage;
 // use async_std::task::sleep;
-use diesel::{Connection, PgConnection, RunQueryDsl};
+use diesel::{
+    Connection,
+    PgConnection,
+    RunQueryDsl,
+};
 use redis::{
     Commands,
-    streams::{StreamPendingReply, StreamReadReply},
+    streams::{
+        StreamPendingReply,
+        StreamReadReply,
+    },
 };
 use redis_stream_bus::client::Stream;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{
+        BTreeMap,
+        HashMap,
+    },
     env,
     time::Duration,
 };

--- a/common/src/testsuite/redis.rs
+++ b/common/src/testsuite/redis.rs
@@ -1,18 +1,28 @@
 use crate::topic::TopicMessage;
-use diesel::{Connection, PgConnection, RunQueryDsl};
+use diesel::{
+    Connection,
+    PgConnection,
+    RunQueryDsl,
+};
 use redis::{
     Commands,
-    streams::{StreamPendingReply, StreamReadReply},
+    streams::{
+        StreamPendingReply,
+        StreamReadReply,
+    },
 };
 use redis_stream_bus::client::Stream;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use tokio::time::sleep;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{
+        BTreeMap,
+        HashMap,
+    },
     env,
     time::Duration,
 };
+use tokio::time::sleep;
 
 pub struct RedisTestClient {
     client: redis::Client,

--- a/common/tests/env_prefix_test.rs
+++ b/common/tests/env_prefix_test.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Args, EnvPrefix)]
-#[prefix = "TEST"]
+#[env_prefix = "TEST"]
 struct TestConfig {
     #[arg(long, env = "SAMPLE_VAR")]
     sample: String,

--- a/common/tests/env_prefix_test.rs
+++ b/common/tests/env_prefix_test.rs
@@ -1,0 +1,42 @@
+use clap::Args;
+use procedural::EnvPrefix;
+
+#[derive(Debug, Args, EnvPrefix)]
+#[prefix = "TEST"]
+struct TestConfig {
+    #[arg(long, env = "SAMPLE_VAR")]
+    sample: String,
+
+    #[arg(long, env = "OTHER_VAR")]
+    other: String,
+}
+
+#[test]
+fn test_env_prefix_transform() {
+    unsafe {
+        std::env::remove_var("SAMPLE_VAR");
+        std::env::remove_var("OTHER_VAR");
+        std::env::remove_var("TEST_SAMPLE_VAR");
+        std::env::remove_var("TEST_OTHER_VAR");
+
+        // Set up fresh environment
+        std::env::set_var("SAMPLE_VAR", "test_value");
+        std::env::set_var("OTHER_VAR", "other_value");
+    }
+
+    // Transform
+    TestConfig::prepend_envs();
+
+    let test_sample = std::env::var("TEST_SAMPLE_VAR").expect("TEST_SAMPLE_VAR should be set");
+    let test_other = std::env::var("TEST_OTHER_VAR").expect("TEST_OTHER_VAR should be set");
+
+    assert_eq!(test_sample, "test_value");
+    assert_eq!(test_other, "other_value");
+
+    unsafe {
+        std::env::remove_var("SAMPLE_VAR");
+        std::env::remove_var("OTHER_VAR");
+        std::env::remove_var("TEST_SAMPLE_VAR");
+        std::env::remove_var("TEST_OTHER_VAR");
+    }
+}

--- a/deposit/Cargo.toml
+++ b/deposit/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = { workspace = true }
 uuid = { workspace = true }
 chains-rs = { workspace = true }
 common = { path = "../common" }
+procedural ={ workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/deposit/src/database/postgres/config.rs
+++ b/deposit/src/database/postgres/config.rs
@@ -1,16 +1,15 @@
 use clap::Args;
+use procedural::EnvPrefix;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, EnvPrefix)]
+#[prefix = "EZEX_DEPOSIT"]
 #[group(id = "postgres")]
 pub struct Config {
-    #[arg(
-        long = "postgres-database-url",
-        env = "EZEX_DEPOSIT_POSTGRES_DATABASE_URL"
-    )]
+    #[arg(long = "postgres-database-url", env = "POSTGRES_DATABASE_URL")]
     pub database_url: String,
     #[arg(
         long = "postgres-pool-size",
-        env = "EZEX_DEPOSIT_POSTGRES_POOL_SIZE",
+        env = "POSTGRES_POOL_SIZE",
         default_value = "10"
     )]
     pub pool_size: u32,

--- a/deposit/src/database/postgres/config.rs
+++ b/deposit/src/database/postgres/config.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
-#[prefix = "EZEX_DEPOSIT"]
+#[env_prefix = "EZEX_DEPOSIT"]
 #[group(id = "postgres")]
 pub struct Config {
     #[arg(long = "postgres-database-url", env = "POSTGRES_DATABASE_URL")]

--- a/deposit/src/deposit_test.rs
+++ b/deposit/src/deposit_test.rs
@@ -1,7 +1,16 @@
-use crate::kms::mock::MockKmsProvider;
-use crate::kms::provider::KmsProvider;
-use crate::{config::Config, deposit::Deposit};
-use common::{consts::*, testsuite::postgres::PostgresTestDB, topic::deposit};
+use crate::{
+    config::Config,
+    deposit::Deposit,
+    kms::{
+        mock::MockKmsProvider,
+        provider::KmsProvider,
+    },
+};
+use common::{
+    consts::*,
+    testsuite::postgres::PostgresTestDB,
+    topic::deposit,
+};
 use mockall::predicate::*;
 use serde_json::json;
 

--- a/deposit/src/grpc/config.rs
+++ b/deposit/src/grpc/config.rs
@@ -1,8 +1,10 @@
 use clap::Args;
+use procedural::EnvPrefix;
 
-#[derive(Debug, Clone, Args)]
+#[derive(Debug, Clone, Args, EnvPrefix)]
+#[prefix = "EZEX_DEPOSIT"]
 #[group(id = "grpc")]
 pub struct Config {
-    #[arg(long, env = "EZEX_DEPOSIT_GRPC_ADDRESS")]
+    #[arg(long, env = "GRPC_ADDRESS")]
     pub address: String,
 }

--- a/deposit/src/grpc/config.rs
+++ b/deposit/src/grpc/config.rs
@@ -2,7 +2,7 @@ use clap::Args;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
-#[prefix = "EZEX_DEPOSIT"]
+#[env_prefix = "EZEX_DEPOSIT"]
 #[group(id = "grpc")]
 pub struct Config {
     #[arg(long, env = "GRPC_ADDRESS")]

--- a/deposit/tests/service.rs
+++ b/deposit/tests/service.rs
@@ -4,11 +4,13 @@ mod topics;
 use assert_cmd::prelude::*;
 
 use common::testsuite::{
-    self, postgres::PostgresTestDB, redis::RedisTestClient, *
+    self,
+    postgres::PostgresTestDB,
+    redis::RedisTestClient,
+    *,
 };
 use ezex_deposit::grpc::deposit::deposit_service_client::DepositServiceClient;
 use httpmock::prelude::*;
-use tokio::time::sleep;
 use std::{
     process::{
         Child,
@@ -17,6 +19,7 @@ use std::{
     },
     time::Duration,
 };
+use tokio::time::sleep;
 use tonic::transport::Channel;
 
 pub struct TestContext {
@@ -35,7 +38,7 @@ impl TestContext {
         let grpc_address = format!("127.0.0.1:{}", testsuite::pick_unused_port());
 
         let redis_group = "deposit-group-1";
-        let redis = RedisTestClient::new( redis_group);
+        let redis = RedisTestClient::new(redis_group);
         // let redis_con_string = redis.
 
         let mut cmd = Command::cargo_bin("ezex-deposit").unwrap();


### PR DESCRIPTION
## Description

This PR adds a custom derive macro `EnvPrefix` that automatically prepends a configurable prefix to environment variables used by `clap`. This solves the common problem of environment variable namespace conflicts in multi-service applications.

### minor fixes
- [x] Replaced the outdated / public archive rust toolchain github action workflow [actions-rs/toolchain@v1](https://github.com/actions-rs/toolchain/tree/v1/) with  a more concise [gh action](https://github.com/dtolnay/rust-toolchain/tree/master) for installing a Rust toolchain from the famous Rust author - dtolnay.
- [x] fix [protoc missing](https://github.com/ezex-io/ezex-core/actions/runs/14529945138/job/40767964009?pr=12#step:6:738) in linting (clippy) on github action.
- [x] fix formatting check (need to check on rust nightly toolchain). Now formatting check passed, only clippy needs to be rechecked after we fixed all tests.
- [x] add `CARGO_TERM_COLOR` env var in gh workflow - this env var tells cargo to always use colored output in the terminal, even when the output is being redirected. This makes the GitHub Actions logs more readable with color-coded information.
- [x] Introduce new workflow to automatically checking dependencies for known security vulnerabilities. This workflow is triggered **_on schedule_** - Runs daily at midnight OR **_on push_** - whenever any `Cargo.toml` or `Cargo.lock` file changes.

## Related Issue

Resolve #11 
