### PR TITLE
test: writing tests for pagination trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "chrono",
  "clap 4.5.36",
  "diesel 2.2.9",
+ "dotenv",
  "erased-serde",
  "futures",
  "indexmap 2.9.0",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,6 +26,7 @@ procedural = { path = "./procedural" }
 portpicker = { workspace = true }
 erased-serde = "0.3"
 indexmap = "2.7"
+dotenv = {workspace = true}
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/common/src/database/pagination.rs
+++ b/common/src/database/pagination.rs
@@ -1,9 +1,5 @@
 use diesel::{
-    pg::Pg,
-    prelude::*,
-    query_builder::*,
-    query_dsl::methods::LoadQuery,
-    sql_types::BigInt,
+    pg::Pg, prelude::*, query_builder::*, query_dsl::methods::LoadQuery, sql_types::BigInt,
 };
 
 // TODO Add test for me
@@ -72,5 +68,42 @@ where
         out.push_sql(" OFFSET ");
         out.push_bind_param::<BigInt, _>(&self.offset)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use diesel::pg::PgConnection;
+    use diesel::prelude::*;
+    use diesel::dsl::sql;
+
+    fn base_query() -> impl QueryFragment<Pg> + QueryId {
+        sql::<diesel::sql_types::Integer>("SELECT 1")
+    }
+
+    #[test]
+    fn test_paginate_defaults() {
+        let paged = base_query().paginate(1);
+        assert_eq!(paged.page, 1);
+        assert_eq!(paged.per_page, super::DEFAULT_PER_PAGE);
+        assert_eq!(paged.offset, 0);
+    }
+
+    #[test]
+    fn test_per_page_override() {
+        let paged = base_query().paginate(2).per_page(15);
+
+        assert_eq!(paged.per_page, 15);
+        assert_eq!(paged.offset, 15); // (2-1) * 15 = 15
+    }
+
+    #[test]
+    fn test_sql_generation() {
+        let paged = base_query().paginate(3).per_page(20);
+        let generated_sql = debug_query::<Pg, _>(&paged).to_string();
+
+        assert!(generated_sql.contains("LIMIT $1"));
+        assert!(generated_sql.contains("OFFSET $2"));
     }
 }

--- a/common/tests/pagination_test.rs
+++ b/common/tests/pagination_test.rs
@@ -1,0 +1,33 @@
+use diesel::{Connection, PgConnection, RunQueryDsl, sql_query};
+use dotenv::dotenv;
+use std::env;
+
+fn connection() -> PgConnection {
+    dotenv().ok();
+    let database_url = env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
+    PgConnection::establish(&database_url).expect("Error connnecting to databse")
+}
+
+#[test]
+fn test_load_and_count_pages() {
+    let mut conn = connection();
+
+    sql_query("CREATE TEMPORARY TABLE users (id serial PRIMARY KEY, name VARCHAR(255))")
+        .execute(&mut conn)
+        .unwrap();
+    sql_query(
+        "INSERT INTO users (name) VALUES ('Ali'), ('Hossein'), ('Naghi'), ('Akbar'), ('Hasan')",
+    )
+    .execute(&mut conn)
+    .unwrap();
+
+    let base_query = users::table.select(users::name);
+    let (results, total_pages) = base_query
+        .paginate(1)
+        .per_page(2)
+        .load_and_count_pages::<String>(&mut conn)
+        .unwrap();
+
+    assert_eq!(results.len(), 2); // First page => 2 users
+    assert_eq!(total_pages, 2); // 3 users / 2 per page => 2 pages
+}


### PR DESCRIPTION
This pull request adds unit and integration tests for the paginate functionality in the Paginated trait. The tests cover the following:

Unit tests:
- Default values: Verifying the correct default values are set when calling .paginate().
- Override per-page: Ensuring that the .per_page() method properly overrides the default pagination settings.
- SQL generation: Testing that the generated SQL contains the necessary LIMIT and OFFSET clauses for pagination.

Integration test:
- Temporary table setup: A temporary table is created, and dummy data is inserted for testing.
- Pagination: The integration test checks if the load_and_count_pages method works correctly by:
    - Verifying that the correct number of records are returned for a given page (results.len()).
    - Ensuring that the total number of pages (total_pages) is calculated correctly based on the number of records in the table.
- Database interaction: The test ensures that the pagination logic interacts properly with the database and that the queries are executed as expected.

## Related Issue
https://github.com/ezex-io/ezex-core/issues/9

