### PR TITLE
fix: custom proc macro env prefix not apply to env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "dotenvy",
  "erased-serde",
  "futures",
+ "inventory",
  "log",
  "log4rs",
  "mockall",
@@ -1194,6 +1195,7 @@ dependencies = [
  "erased-serde",
  "futures",
  "httpmock",
+ "inventory",
  "log",
  "mockall",
  "nix",
@@ -1806,6 +1808,15 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ prost = "0.13"
 dotenvy = "0.15"
 erased-serde = "0.4"
 procedural = { path = "common/procedural" }
-
+inventory = "0.3"
 # Binary dependencies
 ctrlc = { version = "3.4" }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,6 +26,7 @@ procedural = { path = "./procedural" }
 portpicker = { workspace = true }
 erased-serde = { workspace = true }
 dotenvy = {workspace = true}
+inventory = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/common/procedural/src/lib.rs
+++ b/common/procedural/src/lib.rs
@@ -43,28 +43,29 @@ pub(crate) fn event_key(input: DeriveInput) -> Result<Lit, String> {
                 Err(_) => {
                     // If direct parsing fails, try the more complex approach
                     let meta = attr.meta.clone();
-                    if let Ok(list) = meta.require_list() {
-                        if let Ok(lit) = list.parse_args::<Lit>() {
-                            return Ok(lit);
-                        }
+                    match meta.require_list() {
+                        Ok(list) => match list.parse_args::<Lit>() {
+                            Ok(lit) => Ok(lit),
+                            Err(_) => Err(
+                                "Expected a literal string for event_key, e.g., #[event_key(\"my:event\")]"
+                                    .to_owned(),
+                            ),
+                        },
+                        Err(_) => Err(
+                            "Expected a literal string for event_key, e.g., #[event_key(\"my:event\")]"
+                                .to_owned(),
+                        ),
                     }
-
-                    Err(
-                        "Expected a literal string for event_key, e.g., #[event_key(\"my:event\")]"
-                            .to_owned(),
-                    )
                 }
             }
         }
         None => Err("Need event_key attribute".to_owned()),
     }
 }
-
 /// custom derive macro to generate prefix for env vars
 #[proc_macro_derive(EnvPrefix, attributes(env_prefix))]
 pub fn derive_env_prefix(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-
     // println!("Debug: All attributes: {:?}", ast.attrs);
 
     let prefix = ast

--- a/common/src/config_registry.rs
+++ b/common/src/config_registry.rs
@@ -1,0 +1,60 @@
+use std::{
+    any::TypeId,
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
+
+type PrependEnvsFn = fn();
+
+// Thread-safe registry using Mutex
+pub struct ConfigRegistry {
+    configs: HashMap<TypeId, PrependEnvsFn>,
+}
+
+impl ConfigRegistry {
+    fn new() -> Self {
+        ConfigRegistry {
+            configs: HashMap::new(),
+        }
+    }
+
+    // Register a config type
+    pub fn register<T: 'static>(&mut self, prepend_envs: PrependEnvsFn) {
+        self.configs.insert(TypeId::of::<T>(), prepend_envs);
+    }
+
+    // Apply all registered prefixes
+    pub fn apply_all_prefixes(&self) {
+        for prepend_fn in self.configs.values() {
+            prepend_fn();
+        }
+    }
+}
+
+// Global registry instance using thread-safe OnceLock<Mutex<>>
+static REGISTRY: OnceLock<Mutex<ConfigRegistry>> = OnceLock::new();
+
+// Function to access the registry
+pub fn global_registry() -> &'static Mutex<ConfigRegistry> {
+    REGISTRY.get_or_init(|| Mutex::new(ConfigRegistry::new()))
+}
+
+// Trait for configs that can register themselves
+pub trait RegisterableConfig: 'static {
+    fn register_self();
+}
+
+// Concrete type for inventory collection
+pub struct ConfigRegistrationItem {
+    pub register_fn: fn(),
+}
+
+// Collect all registered configs
+inventory::collect!(ConfigRegistrationItem);
+
+// Function to initialize all configs
+pub fn init_all_configs() {
+    for item in inventory::iter::<ConfigRegistrationItem> {
+        (item.register_fn)();
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod config_registry;
 pub mod consts;
 pub mod database;
 pub mod event;
 pub mod logger;
+pub mod macros;
 pub mod testsuite;
 pub mod utils;

--- a/common/src/logger/config.rs
+++ b/common/src/logger/config.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 use procedural::EnvPrefix;
 
+use crate::register_config;
+
 #[derive(Debug, Clone, Args, EnvPrefix)]
 #[env_prefix = "EZEX_DEPOSIT"]
 #[group(id = "logger")]
@@ -10,3 +12,6 @@ pub struct Config {
     #[arg(long = "logger-level", env = "LOGGER_LEVEL", default_value = "info")]
     pub level: String,
 }
+
+// Automatically register this config
+register_config!(Config);

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -5,11 +5,14 @@
 ///
 /// ## Usage
 ///
-/// ```rust
+/// ```rust,no_run
 /// use common::register_config;
+/// // Import required traits
+/// use clap::Args;
+/// use procedural::EnvPrefix;
 ///
 /// #[derive(Debug, Clone, Args, EnvPrefix)]
-/// #[prefix = "MY_APP"]
+/// #[env_prefix = "MY_APP"]
 /// pub struct Config {
 ///     #[arg(long, env = "SERVER_PORT")]
 ///     pub port: u16,

--- a/common/src/macros.rs
+++ b/common/src/macros.rs
@@ -1,0 +1,65 @@
+/// # Configuration Registration Macro
+///
+/// This macro registers a configuration type with the global config registry.
+/// It enables automatic environment variable prefixing for the registered type.
+///
+/// ## Usage
+///
+/// ```rust
+/// use common::register_config;
+///
+/// #[derive(Debug, Clone, Args, EnvPrefix)]
+/// #[prefix = "MY_APP"]
+/// pub struct Config {
+///     #[arg(long, env = "SERVER_PORT")]
+///     pub port: u16,
+/// }
+///
+/// // Register this config type
+/// register_config!(Config);
+/// ```
+///
+/// ## How It Works
+///
+/// The macro:
+/// 1. Implements the `RegisterableConfig` trait for your config type
+/// 2. Creates a function to register the config with the global registry
+/// 3. Submits the registration function to the inventory system
+///
+/// ## Benefits
+///
+/// - Automatic environment variable prefixing
+/// - No need to manually call `prepend_envs()` for each config type
+/// - Centralized application of prefixes
+///
+/// ## Requirements
+///
+/// The config type must:
+/// - Derive the `EnvPrefix` macro
+/// - Have a `prepend_envs()` method (automatically provided by `EnvPrefix`)
+#[macro_export]
+macro_rules! register_config {
+    ($config_type:ty) => {
+        const _: () = {
+            // Function to register this config
+            fn register_config_fn() {
+                <$config_type as $crate::config_registry::RegisterableConfig>::register_self();
+            }
+
+            // Implement the trait
+            impl $crate::config_registry::RegisterableConfig for $config_type {
+                fn register_self() {
+                    let mut registry = $crate::config_registry::global_registry().lock().unwrap();
+                    registry.register::<Self>(Self::prepend_envs);
+                }
+            }
+
+            // Submit to inventory
+            inventory::submit! {
+                $crate::config_registry::ConfigRegistrationItem {
+                    register_fn: register_config_fn
+                }
+            }
+        };
+    };
+}

--- a/deposit/Cargo.toml
+++ b/deposit/Cargo.toml
@@ -36,6 +36,7 @@ procedural = { workspace = true }
 redis_stream_bus = { workspace = true }
 erased-serde = { workspace = true }
 redis = { workspace = true } # TODO: WE may no need it here
+inventory = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/deposit/src/database/postgres/config.rs
+++ b/deposit/src/database/postgres/config.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use common::register_config;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
@@ -14,3 +15,5 @@ pub struct Config {
     )]
     pub pool_size: u32,
 }
+
+register_config!(Config);

--- a/deposit/src/grpc/config.rs
+++ b/deposit/src/grpc/config.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use common::register_config;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
@@ -8,3 +9,5 @@ pub struct Config {
     #[arg(long = "grpc-address", env = "GRPC_ADDRESS")]
     pub address: String,
 }
+
+register_config!(Config);

--- a/deposit/src/kms/config.rs
+++ b/deposit/src/kms/config.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use common::register_config;
 use procedural::EnvPrefix;
 
 #[derive(Debug, Clone, Args, EnvPrefix)]
@@ -6,3 +7,5 @@ use procedural::EnvPrefix;
 pub struct Config {
     // TODO: gRPC address of ezex_kms
 }
+
+register_config!(Config);


### PR DESCRIPTION
- add registry for macro registration config.
- make sure prepend_envs() to be called explicitly.

Note: This fix won't change help text. By default, clap will display the original environment variable names in the help text, not the prefixed versions. If we want to change, this required a significant custom help generator which I think is not appropriate at this time.
## Related Issue

Fixes #21
